### PR TITLE
Fix timestring handling for Wan video

### DIFF
--- a/scripts/deforum_helpers/run_deforum.py
+++ b/scripts/deforum_helpers/run_deforum.py
@@ -149,10 +149,22 @@ def run_deforum(*args):
                     print(f"Using smart model discovery and direct integration.")
                     
                     # Use the generate function that handles everything
-                    output_dir = generate_wan_video(args, anim_args, video_args, 0, False, False, root, root.animation_prompts, loop_args, parseq_args, freeu_args, controlnet_args, None, None, None, wan_args, None)
-                    
+                    wan_result = generate_wan_video(
+                        args, anim_args, video_args, 0, False, False, root,
+                        root.animation_prompts, loop_args, parseq_args,
+                        freeu_args, controlnet_args, None, None, None,
+                        wan_args, None
+                    )
+
                     print(f"✅ Wan video generation completed successfully!")
-                    print(f"📁 Output directory: {output_dir}")
+                    if isinstance(wan_result, dict):
+                        print(f"📁 Output directory: {wan_result.get('output_dir')}")
+                        # Update timestring and frame count for ffmpeg processing
+                        root.timestring = wan_result.get('timestring', root.timestring)
+                        anim_args.max_frames = wan_result.get('total_frames_generated', anim_args.max_frames)
+                        JobStatusTracker().update_output_info(job_id, outdir=args.outdir, timestring=root.timestring)
+                    else:
+                        print(f"📁 Output directory: {wan_result}")
                     
                 except Exception as e:
                     print(f"{RED}Wan video generation failed: {e}{RESET_COLOR}")

--- a/scripts/deforum_helpers/ui_elements.py
+++ b/scripts/deforum_helpers/ui_elements.py
@@ -1005,19 +1005,19 @@ The auto-discovery will find your models automatically!
             
             mode_description = "I2V chaining"
         
-        generated_videos = [output_file] if output_file else []
-        
+        generation_result = output_file if output_file else None
+
         total_time = time.time() - start_time
-        
-        if generated_videos:
+
+        if generation_result:
             print(f"\n🎉 Wan {mode_description} generation completed!")
             print(f"✅ Generated seamless video with {len(clips_data)} clips using {mode_description}")
             print(f"⏱️ Total time: {total_time:.1f} seconds")
-            print(f"📁 Output file: {generated_videos[0]}")
+            print(f"📁 Output file: {generation_result.get('output_dir')}")
             print(f"🔗 {mode_description} ensures smooth transitions between clips")
-                
-            # Return the output directory for Deforum's video processing
-            return str(output_directory)
+
+            # Return the full generation result dictionary for Deforum's processing
+            return generation_result
         else:
             raise RuntimeError(f"❌ Wan {mode_description} failed")
             


### PR DESCRIPTION
## Summary
- return detailed generation info from `generate_wan_video`
- update `run_deforum` to pick up Wan `timestring` and frame count before ffmpeg processing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_6841b2b79dd08326b6b7b5e35e39fb4e