### PR TITLE
Add FramePack F1 mode

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -64,7 +64,7 @@ def DeforumAnimArgs():
         "animation_mode": {
             "label": "Animation mode",
             "type": "radio",
-            "choices": ['2D', '3D', 'Video Input', 'Interpolation', 'Wan Video'],
+            "choices": ['2D', '3D', 'Video Input', 'Interpolation', 'Wan Video', 'FramePack F1'],
             "value": "2D",
             "info": "control animation mode, will hide non relevant params upon change"
         },
@@ -1464,12 +1464,46 @@ def DeforumOutputArgs():
     }
 
 
+def FramePackF1Args():
+    """Arguments specific to FramePack F1 mode"""
+    return {
+        "f1_image_strength": {
+            "label": "Image Strength (F1 Mode)",
+            "type": "slider",
+            "minimum": 1.0,
+            "maximum": 1.02,
+            "step": 0.001,
+            "value": 1.0,
+            "info": "Influence of the initial image. Higher values stick closer to the start image. (1.0 = 100%)"
+        },
+        "f1_generation_latent_size": {
+            "label": "Generation Latent Size (F1 Mode)",
+            "type": "slider",
+            "minimum": 1,
+            "maximum": 12,
+            "step": 1,
+            "value": 9,
+            "info": "Frames to generate to connect to the initial image. (Recommended: 6-9)"
+        },
+        "f1_trim_start_latent_size": {
+            "label": "Trim Start Frames (F1 Mode)",
+            "type": "slider",
+            "minimum": 0,
+            "maximum": 5,
+            "step": 1,
+            "value": 0,
+            "info": "Frames to trim from the beginning of the video (if noise is present)."
+        }
+    }
+
+
 def get_component_names():
     # Re-enable Wan components (UI level, imports still isolated)
     return ['override_settings_with_file', 'custom_settings_file', *DeforumAnimArgs().keys(), 'animation_prompts',
             'animation_prompts_positive', 'animation_prompts_negative',
             *DeforumArgs().keys(), *DeforumOutputArgs().keys(), *ParseqArgs().keys(), *LoopArgs().keys(),
-            *controlnet_component_names(), *FreeUArgs().keys(), *KohyaHRFixArgs().keys(), *WanArgs().keys()]
+            *controlnet_component_names(), *FreeUArgs().keys(), *KohyaHRFixArgs().keys(), *WanArgs().keys(),
+            *FramePackF1Args().keys()]
 
 
 def get_settings_component_names():
@@ -1495,6 +1529,7 @@ def process_args(args_dict_main, run_id):
     freeu_args = SimpleNamespace(**{name: args_dict_main[name] for name in FreeUArgs()})
     kohya_hrfix_args = SimpleNamespace(**{name: args_dict_main[name] for name in KohyaHRFixArgs()})
     wan_args = SimpleNamespace(**{name: args_dict_main[name] for name in WanArgs()})
+    framepack_f1_args = SimpleNamespace(**{name: args_dict_main[name] for name in FramePackF1Args()})
     controlnet_args = SimpleNamespace(**{name: args_dict_main[name] for name in controlnet_component_names()})
 
     root.animation_prompts = json.loads(args_dict_main['animation_prompts'])
@@ -1545,4 +1580,4 @@ def process_args(args_dict_main, run_id):
     default_img = default_img.resize((args.W, args.H))
     root.default_img = default_img
 
-    return args_loaded_ok, root, args, anim_args, video_args, parseq_args, loop_args, controlnet_args, freeu_args, kohya_hrfix_args, wan_args
+    return args_loaded_ok, root, args, anim_args, video_args, parseq_args, loop_args, controlnet_args, freeu_args, kohya_hrfix_args, wan_args, framepack_f1_args

--- a/scripts/deforum_helpers/gradio_funcs.py
+++ b/scripts/deforum_helpers/gradio_funcs.py
@@ -20,6 +20,11 @@ from .general_utils import get_os
 from .upscaling import process_ncnn_upscale_vid_upload_logic
 from .video_audio_utilities import extract_number, get_quick_vid_info, get_ffmpeg_params
 from .frame_interpolation import process_interp_vid_upload_logic, process_interp_pics_upload_logic, gradio_f_interp_get_fps_and_fcount
+
+
+def toggle_framepack_visibility(mode):
+    """Show FramePack F1 accordion when selected"""
+    return gr.update(visible=(mode == 'FramePack F1'))
 from .vid2depth import process_depth_vid_upload_logic
 
 f_models_path = ph.models_path + '/Deforum'
@@ -31,6 +36,11 @@ def handle_change_functions(l_vars):
     l_vars['enable_ancestral_eta_scheduling'].change(fn=hide_if_false, inputs=l_vars['enable_ancestral_eta_scheduling'], outputs=l_vars['ancestral_eta_schedule'])
     l_vars['enable_ddim_eta_scheduling'].change(fn=hide_if_false, inputs=l_vars['enable_ddim_eta_scheduling'], outputs=l_vars['ddim_eta_schedule'])
     l_vars['animation_mode'].change(fn=change_max_frames_visibility, inputs=l_vars['animation_mode'], outputs=l_vars['max_frames'])
+    l_vars['animation_mode'].change(
+        fn=toggle_framepack_visibility,
+        inputs=l_vars['animation_mode'],
+        outputs=l_vars['framepack_f1_accordion']
+    )
     diffusion_cadence_outputs = [l_vars['diffusion_cadence'], l_vars['guided_images_accord'], l_vars['optical_flow_cadence_row'], l_vars['cadence_flow_factor_schedule'],
                                  l_vars['optical_flow_redo_generation'], l_vars['redo_flow_factor_schedule'], l_vars['diffusion_redo']]
     for output in diffusion_cadence_outputs:

--- a/scripts/deforum_helpers/render_framepack_f1.py
+++ b/scripts/deforum_helpers/render_framepack_f1.py
@@ -1,0 +1,73 @@
+import os
+import torch
+import numpy as np
+from PIL import Image
+
+from modules import shared, sd_models
+
+from ..framepack.hunyuan_video_packed import HunyuanVideoTransformer3DModelPacked
+from ..framepack.k_diffusion_hunyuan import sample_hunyuan
+from ..framepack.hunyuan import vae_encode, vae_decode, encode_prompt_conds
+from ..framepack.utils import resize_and_center_crop, save_bcthw_as_mp4
+
+F1_TRANSFORMER = None
+
+
+def load_f1_model(root):
+    global F1_TRANSFORMER
+    if F1_TRANSFORMER is None:
+        model_path = os.path.join(root.models_path, "framepack", "f1_model_weights.pth")
+        if not os.path.exists(model_path):
+            raise FileNotFoundError(f"FramePack F1 model not found at: {model_path}")
+        print("Loading FramePack F1 model...")
+        # Placeholder load - actual model loading depends on repo structure
+        F1_TRANSFORMER = HunyuanVideoTransformer3DModelPacked()
+        state_dict = torch.load(model_path, map_location=root.device)
+        F1_TRANSFORMER.load_state_dict(state_dict)
+        F1_TRANSFORMER.eval().to(root.device)
+        print("FramePack F1 model loaded.")
+    return F1_TRANSFORMER
+
+
+def render_animation_f1(args, anim_args, video_args, framepack_f1_args, root):
+    """Simplified placeholder implementation for FramePack F1 rendering."""
+    print("Starting FramePack F1 rendering process...")
+    model = load_f1_model(root)
+
+    init_image = Image.open(args.init_image).convert("RGB")
+    init_image = resize_and_center_crop(init_image, (args.W, args.H))
+
+    start_latent = vae_encode(init_image, shared.sd_model.first_stage_model, root.device)
+
+    llama_vec, clip_l_pooler = encode_prompt_conds(
+        tokenizer=shared.sd_model.cond_stage_model.wrapped.tokenizer,
+        text_encoder=shared.sd_model.cond_stage_model.wrapped.transformer,
+        text=anim_args.animation_prompts
+    )
+
+    history_latents = start_latent
+    total_sections = int(max(round((anim_args.max_frames) / (framepack_f1_args.f1_generation_latent_size * 4 - 3)), 1))
+
+    for i_section in range(total_sections):
+        shared.state.job = f"FramePack F1: Section {i_section + 1}/{total_sections}"
+        shared.state.job_no = i_section + 1
+        if shared.state.interrupted:
+            break
+
+        generated_latents = sample_hunyuan(
+            transformer=model,
+            initial_latent=history_latents[:, :, -1:],
+            strength=framepack_f1_args.f1_image_strength,
+            steps=framepack_f1_args.f1_generation_latent_size,
+            llama_vec=llama_vec,
+            clip_l_pooler=clip_l_pooler,
+        )
+
+        history_latents = torch.cat([generated_latents.flip(dims=[2]), history_latents], dim=2)
+
+    final_video_frames = vae_decode(history_latents.flip(dims=[2]), shared.sd_model.first_stage_model)
+
+    output_path = os.path.join(args.outdir, f"{root.timestring}_framepack_f1.mp4")
+    save_bcthw_as_mp4(final_video_frames, output_path, video_args.fps)
+    print(f"FramePack F1 video saved to {output_path}")
+

--- a/scripts/deforum_helpers/run_deforum.py
+++ b/scripts/deforum_helpers/run_deforum.py
@@ -78,7 +78,7 @@ def run_deforum(*args):
         args_dict['self'] = None
         args_dict['p'] = p
         try:
-            args_loaded_ok, root, args, anim_args, video_args, parseq_args, loop_args, controlnet_args, freeu_args, kohya_hrfix_args, wan_args = process_args(args_dict, i)
+            args_loaded_ok, root, args, anim_args, video_args, parseq_args, loop_args, controlnet_args, freeu_args, kohya_hrfix_args, wan_args, framepack_f1_args = process_args(args_dict, i)
         except Exception as e:
             JobStatusTracker().fail_job(job_id, error_type="TERMINAL", message="Invalid arguments.")
             print("\n*START OF TRACEBACK*")
@@ -128,6 +128,9 @@ def run_deforum(*args):
                 render_input_video(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, freeu_args, kohya_hrfix_args, root)#TODO: prettify code
             elif anim_args.animation_mode == 'Interpolation':
                 render_interpolation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, freeu_args, kohya_hrfix_args, root)
+            elif anim_args.animation_mode == 'FramePack F1':
+                from .render_framepack_f1 import render_animation_f1
+                render_animation_f1(args, anim_args, video_args, framepack_f1_args, root)
             elif anim_args.animation_mode == 'Wan Video':
                 # Use direct Wan integration
                 try:

--- a/scripts/deforum_helpers/ui_elements.py
+++ b/scripts/deforum_helpers/ui_elements.py
@@ -112,7 +112,7 @@ def get_tab_run(d, da):
     return {k: v for k, v in {**locals(), **vars()}.items()}
 
 
-def get_tab_keyframes(d, da, dloopArgs):
+def get_tab_keyframes(d, da, dloopArgs, df1):
     components = {}
     with gr.TabItem(f"{emoji_utils.key()} Keyframes"):  # TODO make a some sort of the original dictionary parsing
         with FormRow():
@@ -319,8 +319,13 @@ def get_tab_keyframes(d, da, dloopArgs):
                         fov_schedule = create_gr_elem(da.fov_schedule)
                     with FormRow() as depth_warp_row_6:
                         near_schedule = create_gr_elem(da.near_schedule)
-                    with FormRow() as depth_warp_row_7:
-                        far_schedule = create_gr_elem(da.far_schedule)
+                with FormRow() as depth_warp_row_7:
+                    far_schedule = create_gr_elem(da.far_schedule)
+
+        with gr.Accordion('FramePack F1 Settings', open=True, visible=False) as framepack_f1_accordion:
+            f1_image_strength = create_row(df1.f1_image_strength)
+            f1_generation_latent_size = create_row(df1.f1_generation_latent_size)
+            f1_trim_start_latent_size = create_row(df1.f1_trim_start_latent_size)
 
     return {k: v for k, v in {**locals(), **vars()}.items()}
 

--- a/scripts/deforum_helpers/ui_left.py
+++ b/scripts/deforum_helpers/ui_left.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 import gradio as gr
 from .defaults import get_gradio_html
 from .gradio_funcs import change_css, handle_change_functions
-from .args import DeforumArgs, DeforumAnimArgs, ParseqArgs, DeforumOutputArgs, RootArgs, LoopArgs, FreeUArgs, KohyaHRFixArgs, WanArgs
+from .args import DeforumArgs, DeforumAnimArgs, ParseqArgs, DeforumOutputArgs, RootArgs, LoopArgs, FreeUArgs, KohyaHRFixArgs, WanArgs, FramePackF1Args
 from .deforum_controlnet import setup_controlnet_ui
 from .ui_elements import (get_tab_run, get_tab_keyframes, get_tab_prompts, get_tab_init,
                           get_tab_hybrid, get_tab_output, get_tab_freeu, get_tab_kohya_hrfix)
@@ -34,7 +34,8 @@ def set_arg_lists():
     dku = SimpleNamespace(**KohyaHRFixArgs()) 
     dw = SimpleNamespace(**WanArgs())  # Wan args
     dloopArgs = SimpleNamespace(**LoopArgs())  # Guided imgs args
-    return d, da, dp, dv, dr, dfu, dku, dw, dloopArgs
+    df1 = SimpleNamespace(**FramePackF1Args())
+    return d, da, dp, dv, dr, dfu, dku, dw, dloopArgs, df1
 
 def wan_generate_video():
     """
@@ -108,7 +109,7 @@ Error: {str(e)}
         return f"❌ Error: {str(e)}"
 
 def setup_deforum_left_side_ui():
-    d, da, dp, dv, dr, dfu, dku, dw, dloopArgs = set_arg_lists()
+    d, da, dp, dv, dr, dfu, dku, dw, dloopArgs, df1 = set_arg_lists()
     # set up main info accordion on top of the UI
     with gr.Accordion("Info, Links and Help", open=False, elem_id='main_top_info_accord'):
         gr.HTML(value=get_gradio_html('main'))
@@ -119,7 +120,7 @@ def setup_deforum_left_side_ui():
         with gr.Tabs():
             # Get main tab contents:
             tab_run_params = get_tab_run(d, da)  # Run tab
-            tab_keyframes_params = get_tab_keyframes(d, da, dloopArgs)  # Keyframes tab
+            tab_keyframes_params = get_tab_keyframes(d, da, dloopArgs, df1)  # Keyframes tab
             tab_prompts_params = get_tab_prompts(da)  # Prompts tab
             tab_init_params = get_tab_init(d, da, dp)  # Init tab
             controlnet_dict = setup_controlnet_ui()  # ControlNet tab

--- a/scripts/framepack/model_downloader.py
+++ b/scripts/framepack/model_downloader.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from huggingface_hub import snapshot_download
+
+class ModelDownloader:
+    """Utility class to download FramePack F1 related models"""
+
+    def __init__(self, cache_dir: str | None = None):
+        self.cache_dir = Path(cache_dir) if cache_dir else None
+
+    def _download_repo(self, repo: str):
+        snapshot_download(repo_id=repo, cache_dir=self.cache_dir, local_dir_use_symlinks=False)
+
+    def download_f1(self):
+        """Download repositories required for FramePack F1"""
+        repos = [
+            "hunyuanvideo-community/HunyuanVideo",
+            "lllyasviel/flux_redux_bfl",
+            "lllyasviel/FramePack_F1_I2V_HY_20250503",
+        ]
+        for repo in repos:
+            print(f"Downloading {repo}...")
+            self._download_repo(repo)
+            print(f"Finished downloading {repo}")
+


### PR DESCRIPTION
## Summary
- enable FramePack F1 as a new animation mode in arguments
- create FramePack F1 specific settings and UI
- toggle FramePack UI elements from `gradio_funcs`
- hook FramePack F1 renderer into the main pipeline
- provide placeholder renderer and model downloader for F1 mode

## Testing
- `python -m py_compile scripts/deforum_helpers/args.py`
- `python -m py_compile scripts/deforum_helpers/gradio_funcs.py`
- `python -m py_compile scripts/deforum_helpers/run_deforum.py`
- `python -m py_compile scripts/deforum_helpers/ui_elements.py`
- `python -m py_compile scripts/deforum_helpers/ui_left.py`
- `python -m py_compile scripts/deforum_helpers/render_framepack_f1.py`
- `python -m py_compile scripts/framepack/model_downloader.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_68423f13a9bc8326bc5b283a491ceb5c