### PR TITLE
Fix FramePack import paths

### DIFF
--- a/scripts/deforum_helpers/render_framepack_f1.py
+++ b/scripts/deforum_helpers/render_framepack_f1.py
@@ -5,10 +5,14 @@ from PIL import Image
 
 from modules import shared, sd_models
 
-from framepack.hunyuan_video_packed import HunyuanVideoTransformer3DModelPacked
-from framepack.k_diffusion_hunyuan import sample_hunyuan
-from framepack.hunyuan import vae_encode, vae_decode, encode_prompt_conds
-from framepack.utils import resize_and_center_crop, save_bcthw_as_mp4
+# Import FramePack modules from the scripts package so that they resolve
+# correctly regardless of the current working directory
+from scripts.framepack.hunyuan_video_packed import (
+    HunyuanVideoTransformer3DModelPacked,
+)
+from scripts.framepack.k_diffusion_hunyuan import sample_hunyuan
+from scripts.framepack.hunyuan import vae_encode, vae_decode, encode_prompt_conds
+from scripts.framepack.utils import resize_and_center_crop, save_bcthw_as_mp4
 
 F1_TRANSFORMER = None
 

--- a/scripts/framepack/__init__.py
+++ b/scripts/framepack/__init__.py
@@ -1,0 +1,1 @@
+"FramePack utilities package."


### PR DESCRIPTION
## Summary
- ensure FramePack helper modules import via the `scripts` package
- mark `scripts/framepack` as a Python package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'moviepy')*

------
https://chatgpt.com/codex/tasks/task_e_68426a9132548326abcd5416779a321c