### PR TITLE
Fix diffusers import paths

### DIFF
--- a/scripts/deforum_helpers/wan/models/dit.py
+++ b/scripts/deforum_helpers/wan/models/dit.py
@@ -4,8 +4,8 @@ import math
 import torch
 import torch.cuda.amp as amp
 import torch.nn as nn
-from diffusers.configuration_utils import ConfigMixin, register_to_config
-from diffusers.models.modeling_utils import ModelMixin
+from ...diffusers.configuration_utils import ConfigMixin, register_to_config
+from ...diffusers.models.modeling_utils import ModelMixin
 
 from .attention import flash_attention
 

--- a/scripts/deforum_helpers/wan/models/vace_model.py
+++ b/scripts/deforum_helpers/wan/models/vace_model.py
@@ -2,7 +2,7 @@
 import torch
 import torch.cuda.amp as amp
 import torch.nn as nn
-from diffusers.configuration_utils import register_to_config
+from ...diffusers.configuration_utils import register_to_config
 
 from .model import WanAttentionBlock, WanModel, sinusoidal_embedding_1d
 

--- a/scripts/deforum_helpers/wan/utils/fm_solvers.py
+++ b/scripts/deforum_helpers/wan/utils/fm_solvers.py
@@ -8,14 +8,14 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from diffusers.configuration_utils import ConfigMixin, register_to_config
-from diffusers.schedulers.scheduling_utils import (
+from ...diffusers.configuration_utils import ConfigMixin, register_to_config
+from ...diffusers.schedulers.scheduling_utils import (
     KarrasDiffusionSchedulers,
     SchedulerMixin,
     SchedulerOutput,
 )
-from diffusers.utils import deprecate, is_scipy_available
-from diffusers.utils.torch_utils import randn_tensor
+from ...diffusers.utils import deprecate, is_scipy_available
+from ...diffusers.utils.torch_utils import randn_tensor
 
 if is_scipy_available():
     pass

--- a/scripts/deforum_helpers/wan/utils/fm_solvers_unipc.py
+++ b/scripts/deforum_helpers/wan/utils/fm_solvers_unipc.py
@@ -7,13 +7,13 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from diffusers.configuration_utils import ConfigMixin, register_to_config
-from diffusers.schedulers.scheduling_utils import (
+from ...diffusers.configuration_utils import ConfigMixin, register_to_config
+from ...diffusers.schedulers.scheduling_utils import (
     KarrasDiffusionSchedulers,
     SchedulerMixin,
     SchedulerOutput,
 )
-from diffusers.utils import deprecate, is_scipy_available
+from ...diffusers.utils import deprecate, is_scipy_available
 
 if is_scipy_available():
     import scipy.stats

--- a/scripts/deforum_helpers/wan/wan_simple_integration.py
+++ b/scripts/deforum_helpers/wan/wan_simple_integration.py
@@ -1141,7 +1141,7 @@ class WanSimpleIntegration:
 
         if model_info['type'] == 'T2V': 
             try:
-                from diffusers import AutoPipelineForText2Video 
+                from ...diffusers import AutoPipelineForText2Video
                 
                 print_wan_info(f"Attempting to load {model_info['name']} using AutoPipelineForText2Video (diffusers)...")
                 get_vram_stats(f"Before AutoPipelineForText2Video for {model_info['name']}")

--- a/scripts/framepack/utils.py
+++ b/scripts/framepack/utils.py
@@ -511,7 +511,7 @@ def lazy_positional_encoding(t, repeats=None):
     if not isinstance(t, list):
         t = [t]
 
-    from diffusers.models.embeddings import get_timestep_embedding
+    from ..diffusers.models.embeddings import get_timestep_embedding
 
     te = torch.tensor(t)
     te = get_timestep_embedding(timesteps=te, embedding_dim=256, flip_sin_to_cos=True, downscale_freq_shift=0.0, scale=1.0)


### PR DESCRIPTION
## Summary
- use relative imports in deforum_helpers Wan modules
- use relative imports in framepack utils

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchsparse')*

------
https://chatgpt.com/codex/tasks/task_e_6842a54ed0888326a6e966de9483b091