### PR TITLE
Improve memory management for FramePack F1

### DIFF
--- a/scripts/deforum_helpers/render_framepack_f1.py
+++ b/scripts/deforum_helpers/render_framepack_f1.py
@@ -3,7 +3,13 @@ import torch
 import numpy as np
 from PIL import Image
 
-from modules import shared, sd_models
+from modules import shared
+
+from scripts.framepack.memory import (
+    offload_model_from_device_for_memory_preservation,
+    move_model_to_device_with_memory_preservation,
+    model_on_device,
+)
 
 # Import FramePack modules from the scripts package so that they resolve
 # correctly regardless of the current working directory
@@ -43,21 +49,25 @@ def load_f1_model(root):
         F1_TRANSFORMER = HunyuanVideoTransformer3DModelPacked.from_pretrained(
             model_directory,
             torch_dtype=torch.float16,
+            map_location="cpu",
         )
-        F1_TRANSFORMER.eval().to(root.device)
-        print("FramePack F1 model loaded.")
+        F1_TRANSFORMER.eval()
+        print("FramePack F1 model loaded to CPU.")
     return F1_TRANSFORMER
 
 
 def render_animation_f1(args, anim_args, video_args, framepack_f1_args, root):
-    """Simplified placeholder implementation for FramePack F1 rendering."""
-    print("Starting FramePack F1 rendering process...")
-    model = load_f1_model(root)
+    """Render video with FramePack F1 while carefully managing GPU memory."""
+    print("Starting FramePack F1 rendering process with memory management...")
 
-    init_image = np.array(Image.open(args.init_image).convert("RGB"))
-    init_image = resize_and_center_crop(init_image, args.W, args.H)
+    unet = shared.sd_model.model.diffusion_model
+    vae = shared.sd_model.first_stage_model
 
-    start_latent = vae_encode(init_image, shared.sd_model.first_stage_model)
+    # 1. Encode the initial image with the VAE on GPU
+    with model_on_device(vae, root.device):
+        init_image = np.array(Image.open(args.init_image).convert("RGB"))
+        init_image = resize_and_center_crop(init_image, args.W, args.H)
+        start_latent = vae_encode(init_image, vae)
 
     llama_vec, clip_l_pooler = encode_prompt_conds(
         anim_args.animation_prompts,
@@ -67,28 +77,40 @@ def render_animation_f1(args, anim_args, video_args, framepack_f1_args, root):
         getattr(shared.sd_model.cond_stage_model.wrapped, "tokenizer_2", shared.sd_model.cond_stage_model.wrapped.tokenizer),
     )
 
+    # Free memory used by UNet before loading F1
+    offload_model_from_device_for_memory_preservation(unet, root.device)
+
+    model = load_f1_model(root)
     history_latents = start_latent
     total_sections = int(max(round((anim_args.max_frames) / (framepack_f1_args.f1_generation_latent_size * 4 - 3)), 1))
 
-    for i_section in range(total_sections):
-        shared.state.job = f"FramePack F1: Section {i_section + 1}/{total_sections}"
-        shared.state.job_no = i_section + 1
-        if shared.state.interrupted:
-            break
+    with model_on_device(model, root.device):
+        history_latents = history_latents.to(root.device)
 
-        generated_latents = sample_hunyuan(
-            transformer=model,
-            initial_latent=history_latents[:, :, -1:],
-            strength=framepack_f1_args.f1_image_strength,
-            steps=framepack_f1_args.f1_generation_latent_size,
-            llama_vec=llama_vec,
-            clip_l_pooler=clip_l_pooler,
-        )
+        for i_section in range(total_sections):
+            shared.state.job = f"FramePack F1: Section {i_section + 1}/{total_sections}"
+            shared.state.job_no = i_section + 1
+            if shared.state.interrupted:
+                break
 
-        history_latents = torch.cat([generated_latents.flip(dims=[2]), history_latents], dim=2)
+            generated_latents = sample_hunyuan(
+                transformer=model,
+                initial_latent=history_latents[:, :, -1:],
+                strength=framepack_f1_args.f1_image_strength,
+                steps=framepack_f1_args.f1_generation_latent_size,
+                llama_vec=llama_vec,
+                clip_l_pooler=clip_l_pooler,
+            )
 
-    final_video_frames = vae_decode(history_latents.flip(dims=[2]), shared.sd_model.first_stage_model)
+            history_latents = torch.cat([generated_latents.flip(dims=[2]), history_latents], dim=2)
+
+    # 3. Decode with VAE back on GPU
+    with model_on_device(vae, root.device):
+        final_video_frames = vae_decode(history_latents.flip(dims=[2]), vae)
 
     output_path = os.path.join(args.outdir, f"{root.timestring}_framepack_f1.mp4")
     save_bcthw_as_mp4(final_video_frames, output_path, video_args.fps)
     print(f"FramePack F1 video saved to {output_path}")
+
+    # Restore UNet for any further processing
+    move_model_to_device_with_memory_preservation(unet, root.device)

--- a/scripts/framepack/memory.py
+++ b/scripts/framepack/memory.py
@@ -132,3 +132,16 @@ def load_model_as_complete(model, target_device, unload=True):
 
     gpu_complete_modules.append(model)
     return
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def model_on_device(model, target_device, preserved_memory_gb=0):
+    """Context manager to temporarily move a model to a device and restore it."""
+    move_model_to_device_with_memory_preservation(model, target_device, preserved_memory_gb)
+    try:
+        yield model
+    finally:
+        offload_model_from_device_for_memory_preservation(model, target_device, preserved_memory_gb)


### PR DESCRIPTION
## Summary
- load FramePack F1 model on CPU first
- add `model_on_device` context manager to `memory.py`
- use the context manager in FramePack renderer to keep only one large model on the GPU at a time

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'moviepy.editor')*

------
https://chatgpt.com/codex/tasks/task_e_6842f30cbb64832680a6fdf22245d6ab