### PR TITLE
Fix device handling in FramePack wrappers

### DIFF
--- a/scripts/framepack/k_diffusion_hunyuan.py
+++ b/scripts/framepack/k_diffusion_hunyuan.py
@@ -76,7 +76,7 @@ def sample_hunyuan(
 
     sigmas = get_flux_sigmas_from_mu(num_inference_steps, mu).to(device)
 
-    k_model = fm_wrapper(transformer)
+    k_model = fm_wrapper(transformer, device=device)
 
     if initial_latent is not None:
         sigmas = sigmas * strength

--- a/scripts/framepack/wrapper.py
+++ b/scripts/framepack/wrapper.py
@@ -16,13 +16,8 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=1.0):
     return noise_cfg
 
 
-def fm_wrapper(transformer, t_scale=1000.0):
+def fm_wrapper(transformer, device, t_scale=1000.0):
     def k_model(x, sigma, **extra_args):
-        # --- ▼▼▼ 修正箇所 ▼▼▼ ---
-        # 1. transformerモデル自身がどのデバイスにいるかを取得し、変数`device`に格納します。
-        #    これにより、コードがCPU/GPUどちらで実行されても対応できます。
-        device = next(transformer.parameters()).device
-        # --- ▲▲▲ 修正箇所 ▲▲▲ ---
 
         dtype = extra_args['dtype']
         cfg_scale = extra_args['cfg_scale']
@@ -31,12 +26,9 @@ def fm_wrapper(transformer, t_scale=1000.0):
 
         original_dtype = x.dtype
         
-        # --- ▼▼▼ 修正箇所 ▼▼▼ ---
-        # 2. 入力テンソル`x`と`sigma`を、手順1で取得した`device`に明示的に転送します。
-        #    `x`はデータ型も同時に変換します。これがデバイス不整合エラーを直接解決します。
+        # Move input tensors to the specified device and dtype.
         x = x.to(device, dtype=dtype)
         sigma = sigma.to(device).float()
-        # --- ▲▲▲ 修正箇所 ▲▲▲ ---
 
         timestep = (sigma * t_scale).to(dtype)
 


### PR DESCRIPTION
## Summary
- pass `device` into `fm_wrapper` so tensor moves are accurate
- remove auto device detection logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchsparse')*

------
https://chatgpt.com/codex/tasks/task_e_68452f985d788326838c66505c42a593