### PR TITLE
Fix Framepack device handling

### DIFF
--- a/scripts/framepack/integration.py
+++ b/scripts/framepack/integration.py
@@ -299,7 +299,7 @@ class FramepackIntegration:
             shared.state.job_no = i_section + 1
             if shared.state.interrupted:
                 break
-                
+
             generated_latents = sample_hunyuan(
                 transformer=f1_transformer,
                 initial_latent=history_latents[:, :, -1:],
@@ -312,6 +312,7 @@ class FramepackIntegration:
                 height=args.H,
                 image_embeds=image_embeds,
                 indices_latents=indices_latents,
+                device=self.device,
             )
 
             history_latents = torch.cat([history_latents, generated_latents], dim=2)

--- a/scripts/framepack/wrapper.py
+++ b/scripts/framepack/wrapper.py
@@ -27,13 +27,14 @@ def fm_wrapper(transformer, device, t_scale=1000.0):
         original_dtype = x.dtype
         
         # --- ▼▼▼【修正箇所】▼▼▼ ---
-        # 1. モデルのパラメータが実際に存在するデバイスを取得
-        model_device = next(transformer.parameters()).device
-        
-        # 2. 【デバッグログ】各デバイスの状態を出力
-        print(f"[DEBUG wrapper.py] Devices: input_x={x.device}, sampler_arg={device}, actual_model_params={model_device}")
+        # 1. 推論に使用するターゲットデバイスを明示的に使用
+        model_device = device
 
-        # 3. 入力テンソルをモデルと同じデバイスに移動
+        # 2. 【デバッグログ】各デバイスの状態を出力
+        actual_device = next(transformer.parameters()).device
+        print(f"[DEBUG wrapper.py] Devices: input_x={x.device}, sampler_arg={device}, actual_model_params={actual_device}")
+
+        # 3. 入力テンソルをターゲットデバイスに移動
         x = x.to(device=model_device, dtype=dtype)
         sigma = sigma.to(device=model_device).float()
         # --- ▲▲▲【修正箇所】▲▲▲ ---


### PR DESCRIPTION
## Summary
- ensure sampling uses GPU device
- align latent tensors with target device

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchsparse')*

------
https://chatgpt.com/codex/tasks/task_e_6845519b3aa883268746fa1d141fc5c4