### PR TITLE
Add LoRA slots for FramePack F1 mode

### DIFF
--- a/scripts/deforum_helpers/ui_elements.py
+++ b/scripts/deforum_helpers/ui_elements.py
@@ -326,6 +326,9 @@ def get_tab_keyframes(d, da, dloopArgs, df1):
             f1_image_strength = create_row(df1.f1_image_strength)
             f1_generation_latent_size = create_row(df1.f1_generation_latent_size)
             f1_trim_start_latent_size = create_row(df1.f1_trim_start_latent_size)
+            lora_row_1 = create_row(df1.lora_path_1, df1.lora_weight_1)
+            lora_row_2 = create_row(df1.lora_path_2, df1.lora_weight_2)
+            lora_row_3 = create_row(df1.lora_path_3, df1.lora_weight_3)
 
     return {k: v for k, v in {**locals(), **vars()}.items()}
 


### PR DESCRIPTION
## Summary
- allow FramePack F1 mode to select up to three LoRA files and weights
- collect LoRA slots in processing and expose through UI

## Testing
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_684add96de748326892f6ae32ab46f74