### PR TITLE
Fix default visibility and value for FramePack F1

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -1477,10 +1477,10 @@ def FramePackF1Args():
         "f1_image_strength": {
             "label": "Image Strength (F1 Mode)",
             "type": "slider",
-            "minimum": 1.0,
-            "maximum": 1.02,
-            "step": 0.001,
-            "value": 1.8,
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "step": 0.01,
+            "value": 0.85,
             "info": "Influence of the initial image. Higher values stick closer to the start image. (1.0 = 100%)",
         },
         "f1_generation_latent_size": {

--- a/scripts/deforum_helpers/ui_elements.py
+++ b/scripts/deforum_helpers/ui_elements.py
@@ -322,7 +322,8 @@ def get_tab_keyframes(d, da, dloopArgs, df1):
                 with FormRow() as depth_warp_row_7:
                     far_schedule = create_gr_elem(da.far_schedule)
 
-        with gr.Accordion('FramePack F1 Settings', open=True, visible=False) as framepack_f1_accordion:
+        with gr.Accordion('FramePack F1 Settings', open=True,
+                          visible=(da.animation_mode == 'FramePack F1')) as framepack_f1_accordion:
             f1_image_strength = create_row(df1.f1_image_strength)
             f1_generation_latent_size = create_row(df1.f1_generation_latent_size)
             f1_trim_start_latent_size = create_row(df1.f1_trim_start_latent_size)


### PR DESCRIPTION
## Summary
- show the FramePack F1 settings accordion if Animation mode defaults to FramePack F1
- adjust `Image Strength (F1 Mode)` slider to a 0–1 range with a reasonable default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684db06a47588326a448ea712293f47d