### PR TITLE
Fix FramePack F1 UI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Teacache、fp8利用はデフォルトで適用しています。Loraも使用�
 
 ![Framepack F1 設定画面](docs/FramepackF1setting.png)
 
-Image Strength (F1 Mode)　：　デフォルト値が１です。これを下げると動きが小さくなります
+Image Strength (F1 Mode)　：　デフォルト値は1.0です。これを下げると動きが小さくなります
 
 Generation Latent Size (F1 Mode)　：　1チャンクあたりのキーフレーム数です。デフォルト値が9です
 
-Trim Start Frames (F1 Mode)　：　基本使わなくて良いかと思います
+Context Damping Factor (F1 Mode)　：　コンテキストの影響をほどよく減衰させる値です。デフォルトは1.08、上限1.2、下限1.0で設定できます
 
 Lora　：　3個まで設定可能です。Loraフォルダ直下にあるファイルが認識されます。
 

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -1477,10 +1477,10 @@ def FramePackF1Args():
         "f1_image_strength": {
             "label": "Image Strength (F1 Mode)",
             "type": "slider",
-            "minimum": 0.99,
+            "minimum": 0.98,
             "maximum": 1.0,
             "step": 0.0001,
-            "value": 1.8,
+            "value": 1.0,
             "info": "Influence of the initial image. Higher values stick closer to the start image. (1.0 = 100%)",
         },
         "f1_generation_latent_size": {
@@ -1492,14 +1492,14 @@ def FramePackF1Args():
             "value": 9,
             "info": "Frames to generate to connect to the initial image. (Recommended: 6-9)",
         },
-        "f1_trim_start_latent_size": {
-            "label": "Trim Start Frames (F1 Mode)",
+        "f1_context_damping_factor": {
+            "label": "Context Damping Factor",
             "type": "slider",
-            "minimum": 0,
-            "maximum": 5,
-            "step": 1,
-            "value": 0,
-            "info": "Frames to trim from the beginning of the video (if noise is present).",
+            "minimum": 1.0,
+            "maximum": 1.2,
+            "step": 0.01,
+            "value": 1.08,
+            "info": "Damping factor applied to context latents.",
         },
         "lora_path_1": {
             "label": "LoRA Slot 1",

--- a/scripts/deforum_helpers/ui_elements.py
+++ b/scripts/deforum_helpers/ui_elements.py
@@ -326,7 +326,7 @@ def get_tab_keyframes(d, da, dloopArgs, df1):
                           visible=(da.animation_mode == 'FramePack F1')) as framepack_f1_accordion:
             f1_image_strength = create_row(df1.f1_image_strength)
             f1_generation_latent_size = create_row(df1.f1_generation_latent_size)
-            f1_trim_start_latent_size = create_row(df1.f1_trim_start_latent_size)
+            f1_context_damping_factor = create_row(df1.f1_context_damping_factor)
             lora_path_1, lora_weight_1 = create_row(df1, 'lora_path_1', 'lora_weight_1')
             lora_path_2, lora_weight_2 = create_row(df1, 'lora_path_2', 'lora_weight_2')
             lora_path_3, lora_weight_3 = create_row(df1, 'lora_path_3', 'lora_weight_3')

--- a/scripts/framepack/tensor_tool.py
+++ b/scripts/framepack/tensor_tool.py
@@ -157,7 +157,7 @@ def execute_generation(managers: dict, device, args, anim_args, video_args, fram
 
         # 履歴コンテキストの影響をわずかに減衰させる（例: 5%減）
         # これにより、過去のフレームの残像効果を弱めることを狙う
-        damping_factor = 1.08
+        damping_factor = getattr(framepack_f1_args, 'f1_context_damping_factor', 1.08)
         clean_latents = clean_latents * damping_factor
         print(f"[tensor_tool] Applied context damping with factor: {damping_factor}")
 


### PR DESCRIPTION
## Summary
- correct F1 Image Strength defaults
- repurpose trim start frames setting to context damping factor
- expose new damping parameter in tensor_tool
- document changes in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchsparse')*

------
https://chatgpt.com/codex/tasks/task_e_684f5e6594bc8326b28f5acebd7349f5